### PR TITLE
Change README links

### DIFF
--- a/00-Prerequisites/02-Preparation/README.md
+++ b/00-Prerequisites/02-Preparation/README.md
@@ -8,9 +8,9 @@ Our workshop assumes some basic knowledge about Python programming language and 
     - an introduction to `Python` as a programming language. We cover data types and useful built-in functions as well as how to define a _function_ and _class_ in Python.
 3. [Python-03-Numpy](/00-Prerequisites/02-Preparation/Python-03-Numpy.ipynb)
     - an introduction to `numpy`, the most popular scientific library in Python that is used as the base or supported by other scientific libraries. We cover data types, arrays and operations on arrays, linear algebra, random numbers, etc.
-4. [Python-04-ScientificPython](/00-Prerequisites/02-Preparation/Python-04-Jupyter.ipynb)
+4. [Python-04-ScientificPython](/00-Prerequisites/02-Preparation/Python-04-ScientificPython.ipynb)
     - an introduction to visualization tools, fitting a function, saving data into a file, etc..
-5. [Python-05-Pytorch](/00-Prerequisites/02-Preparation/Python-05-Pytorch.ipynb)
+5. [Python-05-Pytorch](/00-Prerequisites/02-Preparation/Python-05-PyTorch.ipynb)
     - an introduction to Pytorch, one of most popular machine learning libraries, covering a tensor data type, a data streaming tool, and a concept of computation graph    
 6. [Python-06-MNIST-CIFAR10](/00-Prerequisites/02-Preparation/Python-06-MNIST-CIFAR10.ipynb)
     - a brief overview on two public datasets we will use: MNIST and CIFAR10. Demonstrate how to download, access, visualize, and put into a DataLoader. 


### PR DESCRIPTION
I noticed that two of the links for sections 4 and 5 of the 02-Preparation README weren't working for me. It looks like two of the URLs were pointing to different files. These changes seem to fix the issue in my fork. @yee379 